### PR TITLE
FIX: Handle report object correctly

### DIFF
--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -169,7 +169,7 @@ class PrintingPrinter(models.Model):
         for option, value in print_opts.items():
             try:
                 options.update(getattr(
-                    self, '_set_option_%s' % option)(report, value))
+                    self, '_set_option_%s' % option)(report.report_name, value))
             except AttributeError:
                 options[option] = str(value)
         return options
@@ -184,8 +184,6 @@ class PrintingPrinter(models.Model):
         _logger.debug(
             'Sending job to CUPS printer %s on %s'
             % (self.system_name, self.server_id.address))
-        if isinstance(report, str):
-            report = self.env['ir.actions.report']._get_report_from_name(report)
         name = f"{self.env.user.firstname or self.env.user.name[:3]} {report.name}"\
             if report else file_name
         connection.printFile(

--- a/printer_custom_options/models/printing_printer.py
+++ b/printer_custom_options/models/printing_printer.py
@@ -108,10 +108,7 @@ class PrintingPrinter(models.Model):
         options = super().print_options(report=report, **print_opts)
 
         if report is not None:
-            # Some modules pass report_name instead of the report.
-            full_report = self.env['ir.actions.report']._get_report_from_name(report) \
-                if isinstance(report, str) else report
-            for printer_option in full_report.printer_options:
-                options[
-                    printer_option.option_key] = printer_option.option_value
+            for printer_option in report.printer_options:
+                options[printer_option.option_key] = printer_option.option_value
+
         return options


### PR DESCRIPTION
_Related Issue: T0075 - Print reminder print duplex_

The original code used ```_get_report_from_name()```  method to retrieve the report object, which could lead to getting a wrong report object if there are multiple reports with the same name, like in our environment.

This method gets the first result, it's not optimized in our case.

The updated code now directly uses the report object passed to the method to get the printer options, ensuring that the correct report object is used.

There was a comment saying `# Some modules pass report_name instead of the report.`
but after looking on our code, I didn't find any case except the case related to the related pull requests
Related Pull Request: [1548](https://github.com/CompassionCH/compassion-switzerland/pull/1548), [1729](https://github.com/CompassionCH/compassion-modules/pull/1729)